### PR TITLE
Continues parsing of Pax responses in the event of duplicate response…

### DIFF
--- a/Example/Heartland-iOS-SDK/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/Heartland-iOS-SDK/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -84,11 +84,6 @@
       "idiom" : "ipad",
       "size" : "83.5x83.5",
       "scale" : "2x"
-    },
-    {
-      "idiom" : "ios-marketing",
-      "size" : "1024x1024",
-      "scale" : "1x"
     }
   ],
   "info" : {

--- a/Example/Heartland-iOS-SDK/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/Heartland-iOS-SDK/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -84,6 +84,11 @@
       "idiom" : "ipad",
       "size" : "83.5x83.5",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/Pod/Classes/Terminals/PAX/Models/HpsPaxCreditResponse.m
+++ b/Pod/Classes/Terminals/PAX/Models/HpsPaxCreditResponse.m
@@ -14,7 +14,7 @@
 
 - (HpsBinaryDataScanner*) parseResponse{
     HpsBinaryDataScanner *reader = [super parseResponse];
-    if ([self.deviceResponseCode isEqualToString:@"000000"]) {
+    if ([self.deviceResponseCode isEqualToString:@"000000"] || [self.deviceResponseCode isEqualToString:@"100011"]) {
         
         self.hostResponse = [[HpsPaxHostResponse alloc] initWithBinaryReader:reader];
         self.transactionType = [reader readStringUntilDelimiter:HpsControlCodes_FS];

--- a/Pod/Classes/Terminals/PAX/Models/HpsPaxDebitResponse.m
+++ b/Pod/Classes/Terminals/PAX/Models/HpsPaxDebitResponse.m
@@ -13,7 +13,7 @@
 
 - (HpsBinaryDataScanner*) parseResponse{
     HpsBinaryDataScanner *reader = [super parseResponse];
-    if ([self.deviceResponseCode isEqualToString:@"000000"]) {
+    if ([self.deviceResponseCode isEqualToString:@"000000"] || [self.deviceResponseCode isEqualToString:@"100011"]) {
         
         self.hostResponse = [[HpsPaxHostResponse alloc] initWithBinaryReader:reader];
         self.transactionType = [reader readStringUntilDelimiter:HpsControlCodes_FS];


### PR DESCRIPTION
… code (100011)

The response values for a duplicate are valuable, particularly the Host info and the Trace info, which can be used to reconcile a missing transaction, which could've been lost due to timeout or network outage.