### PR TITLE
adds PaxGiftActivate builder

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -294,6 +294,8 @@
 		E99673A6069496CC929767F4236A276F /* HpsCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A310D5B03A0DCC7D8E083764B4626CE /* HpsCommon.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA4876DA6A2BB12601E734789596E570 /* HpsHpaRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 7283C3755852A337C5E25E89EAEC8ACC /* HpsHpaRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EB53C5B58780469BBE66E4029BE281D7 /* HpsPaxCreditReturnBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = C033A791600929743D0C204567BDA1DF /* HpsPaxCreditReturnBuilder.m */; };
+		EC406E3E2252B4B2008D365E /* HpsPaxGiftActivateBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = EC406E3C2252B4B2008D365E /* HpsPaxGiftActivateBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC406E3F2252B4B2008D365E /* HpsPaxGiftActivateBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = EC406E3D2252B4B2008D365E /* HpsPaxGiftActivateBuilder.m */; };
 		ED0C8886CCDC171EFF1233D867085B92 /* HpsHpaResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B0CC9275A5F527B01B0418041D8A562 /* HpsHpaResponse.m */; };
 		EDCE453F5AEDB595CCCE096B1CF5C1A2 /* HpsConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 24457C988E926C66D3E000B8AC6B8C7B /* HpsConfiguration.m */; };
 		F04F0BA30B75AA1E59AB21ED86278461 /* HpsHpaGiftVoidBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = DA77B99D5F552C313D724D8D15E59032 /* HpsHpaGiftVoidBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -665,6 +667,8 @@
 		EB71306685E7C20839A5532E8FD40FDF /* HpsPayItem.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = HpsPayItem.m; sourceTree = "<group>"; };
 		EB9EDFC4696C60D707B6FC089B65C631 /* HpsCardEntry.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = HpsCardEntry.m; sourceTree = "<group>"; };
 		EBF84C38915224A745321A6D5E3E2D8C /* XMLDictionary-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XMLDictionary-prefix.pch"; sourceTree = "<group>"; };
+		EC406E3C2252B4B2008D365E /* HpsPaxGiftActivateBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HpsPaxGiftActivateBuilder.h; sourceTree = "<group>"; };
+		EC406E3D2252B4B2008D365E /* HpsPaxGiftActivateBuilder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HpsPaxGiftActivateBuilder.m; sourceTree = "<group>"; };
 		EDC993578040114307166CD19199F063 /* HpsDeviceProtocols.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = HpsDeviceProtocols.h; sourceTree = "<group>"; };
 		EE0789A7F58A75A360C5DF477B105BEE /* HpsAdditionalTxnFields.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = HpsAdditionalTxnFields.m; sourceTree = "<group>"; };
 		EEAEDFDBEAF3BE232C40D354A9D189A1 /* HpsBasePayrollResponse.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = HpsBasePayrollResponse.h; sourceTree = "<group>"; };
@@ -1228,6 +1232,8 @@
 				CC6DDE1747A55518973657A091A49F11 /* HpsPaxDebitReturnBuilder.m */,
 				878F5AC2991F3433048DAC2E6E9784D2 /* HpsPaxDebitSaleBuilder.h */,
 				478D4400BCDA0BCDB31E137F2B536349 /* HpsPaxDebitSaleBuilder.m */,
+				EC406E3C2252B4B2008D365E /* HpsPaxGiftActivateBuilder.h */,
+				EC406E3D2252B4B2008D365E /* HpsPaxGiftActivateBuilder.m */,
 				FEB895DA5D506598B292F6790811FC8C /* HpsPaxGiftAddValueBuilder.h */,
 				11DCFE61349F9A88B8420CD9E743A610 /* HpsPaxGiftAddValueBuilder.m */,
 				BA6E162EDC11573B3AF40FBDFB07BCEF /* HpsPaxGiftBalanceBuilder.h */,
@@ -1503,6 +1509,7 @@
 				71E743D4619E629DD075DE7BBEFD156A /* HpsHpaResponse.h in Headers */,
 				5FC8DC2734A5C23D10A134443D92484F /* HpsHpaSharedParams.h in Headers */,
 				831F6B073EBB1450714D994EFE53AAAC /* HpsHpaStartCardBuilder.h in Headers */,
+				EC406E3E2252B4B2008D365E /* HpsPaxGiftActivateBuilder.h in Headers */,
 				69ACCC7A110BA1B0CD00A99E54553404 /* HpsHpaTcpInterface.h in Headers */,
 				0EC3560684F6B0C95B9C00D1F81791EC /* HpsJsonDoc.h in Headers */,
 				D3944D7713AEAAF9CCA50C9C950BBDA4 /* HpsLaborField.h in Headers */,
@@ -1880,6 +1887,7 @@
 				31047F425C055E20F315B31A9405CC34 /* HpsPayItem.m in Sources */,
 				8F1D246E75B6370AD6761D601EFF80EE /* HpsPayrollCollectionItem.m in Sources */,
 				2567F8A19387324AA7CB6F78FF4CECA0 /* HpsPayrollConfig.m in Sources */,
+				EC406E3F2252B4B2008D365E /* HpsPaxGiftActivateBuilder.m in Sources */,
 				F1EFF88826A0C992EE4D2D99C773157A /* HpsPayrollEncoder.m in Sources */,
 				33CCA5C4303F5EE4014FCA150D363038 /* HpsPayrollEntity.m in Sources */,
 				D64B985E03349BA1EE379A4185D6FC08 /* HpsPayrollRecord.m in Sources */,

--- a/Example/Pods/Target Support Files/Heartland-iOS-SDK/Heartland-iOS-SDK-umbrella.h
+++ b/Example/Pods/Target Support Files/Heartland-iOS-SDK/Heartland-iOS-SDK-umbrella.h
@@ -113,6 +113,7 @@
 #import "HpsPaxCreditVoidBuilder.h"
 #import "HpsPaxDebitReturnBuilder.h"
 #import "HpsPaxDebitSaleBuilder.h"
+#import "HpsPaxGiftActivateBuilder.h"
 #import "HpsPaxGiftAddValueBuilder.h"
 #import "HpsPaxGiftBalanceBuilder.h"
 #import "HpsPaxGiftSaleBuilder.h"

--- a/Example/Tests/Hps_Pax_Gift_Tests.m
+++ b/Example/Tests/Hps_Pax_Gift_Tests.m
@@ -5,6 +5,7 @@
 #import "HpsPaxGiftResponse.h"
 #import "HpsPaxGiftSaleBuilder.h"
 #import "HpsPaxGiftAddValueBuilder.h"
+#import "HpsPaxGiftActivateBuilder.h"
 #import "HpsPaxGiftBalanceBuilder.h"
 #import "HpsPaxGiftVoidBuilder.h"
 
@@ -158,6 +159,32 @@
 	}];
 }
 
+
+- (void) test_PAX_HTTP_Gift_Activate
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"test_PAX_HTTP_Gift_Activate"];
+    
+    HpsPaxDevice *device = [self setupDevice];
+    HpsGiftCard *card = [self getCard];
+    
+    HpsPaxGiftActivateBuilder *builder = [[HpsPaxGiftActivateBuilder alloc] initWithDevice:device];
+    builder.amount = [NSNumber numberWithDouble:13.0];
+    builder.referenceNumber = 7;
+    builder.giftCard = card;
+    
+    [builder execute:^(HpsPaxGiftResponse *payload, NSError *error) {
+        XCTAssertNil(error);
+        XCTAssertNotNil(payload);
+        XCTAssertEqualObjects(@"0", payload.responseCode);
+        [expectation fulfill];
+    
+    }];
+    
+    [self waitForExpectationsWithTimeout:60.0 handler:^(NSError *error) {
+        if(error) XCTFail(@"Request Timed out");
+    }];
+}
+
 - (void) test_PAX_HTTP_Gift_AddValue
 {
 	XCTestExpectation *expectation = [self expectationWithDescription:@"test_PAX_HTTP_Gift_AddValue"];
@@ -232,6 +259,29 @@
 	}];
 }
 
+- (void) test_PAX_HTTP_Gift_Activate_Fail_No_Amount
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"test_PAX_HTTP_Gift_Activate_Fail_No_Amount"];
+    
+    HpsPaxDevice *device = [self setupDevice];
+    
+    HpsPaxGiftActivateBuilder *builder = [[HpsPaxGiftActivateBuilder alloc] initWithDevice:device];
+    builder.referenceNumber = 9;
+    
+    @try {
+        [builder execute:^(HpsPaxGiftResponse *payload, NSError *error) {
+            
+            XCTFail(@"Request not allowed but returned");
+        }];
+    } @catch (NSException *exception) {
+        [expectation fulfill];
+    }
+    
+    [self waitForExpectationsWithTimeout:60.0 handler:^(NSError *error) {
+        if(error) XCTFail(@"Request Timed out");
+    }];
+}
+
 - (void) test_PAX_HTTP_Gift_AddValue_Fail_No_Currency
 {
 	XCTestExpectation *expectation = [self expectationWithDescription:@"test_PAX_HTTP_Gift_AddValue_Fail_No_Currency"];
@@ -256,6 +306,32 @@
 	[self waitForExpectationsWithTimeout:60.0 handler:^(NSError *error) {
 		if(error) XCTFail(@"Request Timed out");
 	}];
+}
+
+- (void) test_PAX_HTTP_Gift_Activate_Fail_No_Currency
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"test_PAX_HTTP_Gift_Activate_Fail_No_Currency"];
+    
+    HpsPaxDevice *device = [self setupDevice];
+    HpsGiftCard *card = [self getCard];
+    
+    HpsPaxGiftActivateBuilder *builder = [[HpsPaxGiftActivateBuilder alloc] initWithDevice:device];
+    builder.referenceNumber = 10;
+    builder.giftCard = card;
+    builder.currencyType = -1;
+    
+    @try {
+        [builder execute:^(HpsPaxGiftResponse *payload, NSError *error) {
+            
+            XCTFail(@"Request not allowed but returned");
+        }];
+    } @catch (NSException *exception) {
+        [expectation fulfill];
+    }
+    
+    [self waitForExpectationsWithTimeout:60.0 handler:^(NSError *error) {
+        if(error) XCTFail(@"Request Timed out");
+    }];
 }
 
 - (void) test_PAX_HTTP_Gift_Void

--- a/Example/Tests/Hps_Pax_VRF_Test.m
+++ b/Example/Tests/Hps_Pax_VRF_Test.m
@@ -16,6 +16,7 @@
 #import "HpsPaxGiftBalanceBuilder.h"
 #import "HpsPaxGiftResponse.h"
 #import "HpsPaxGiftSaleBuilder.h"
+#import "HpsPaxGiftActivateBuilder.h"
 #import "HpsPaxGiftAddValueBuilder.h"
 #import "HpsPaxBaseResponse.h"
 
@@ -642,6 +643,31 @@
 		if(error) XCTFail(@"Request Timed out");
 	}];
 
+}
+
+- (void) test_case_12d
+{
+    NSLog(@"CONDITIONAL TEST CASE 12 – HMS Gift");
+    [self writeStringToFile:@"CONDITIONAL TEST CASE 12 – HMS Gift Activate \n"];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"test_PAX_HTTP_Gift_Activate"];
+    
+    HpsPaxDevice *device = [self setupDevice];
+    HpsPaxGiftActivateBuilder *builder = [[HpsPaxGiftActivateBuilder alloc] initWithDevice:device];
+    builder.amount = [NSNumber numberWithDouble:8.0];
+    builder.referenceNumber = 19;
+    
+    [builder execute:^(HpsPaxGiftResponse *payload, NSError *error) {
+        XCTAssertNil(error);
+        XCTAssertNotNil(payload);
+        XCTAssertEqualObjects(@"0", payload.responseCode);
+        [self printRecipt:payload];
+        [expectation fulfill];
+        
+    }];
+    
+    [self waitForExpectationsWithTimeout:60.0 handler:^(NSError *error) {
+        if(error) XCTFail(@"Request Timed out");
+    }];
 }
 
 #pragma mark -

--- a/Pod/Classes/Terminals/PAX/Builders/HpsPaxGiftActivateBuilder.h
+++ b/Pod/Classes/Terminals/PAX/Builders/HpsPaxGiftActivateBuilder.h
@@ -1,0 +1,26 @@
+#import <Foundation/Foundation.h>
+#import "HpsTransactionDetails.h"
+#import "HpsPaxMessageIDs.h"
+#import "HpsPaxDevice.h"
+#import "HpsPaxAccountRequest.h"
+#import "HpsPaxCashierSubGroup.h"
+#import "HpsPaxAmountRequest.h"
+#import "HpsPaxTraceRequest.h"
+#import "HpsPaxExtDataSubGroup.h"
+#import "HpsGiftCard.h"
+#import "HpsPaxGiftResponse.h"
+
+@interface HpsPaxGiftActivateBuilder : NSObject
+{
+    HpsPaxDevice *device;
+}
+
+@property (nonatomic, readwrite) int referenceNumber;
+@property (nonatomic, strong) NSNumber *amount;
+@property (nonatomic, strong) HpsGiftCard *giftCard;
+@property (nonatomic) int currencyType;
+
+- (void) execute:(void(^)(HpsPaxGiftResponse*, NSError*))responseBlock;
+- (id)initWithDevice: (HpsPaxDevice*)paxDevice;
+
+@end

--- a/Pod/Classes/Terminals/PAX/Builders/HpsPaxGiftActivateBuilder.m
+++ b/Pod/Classes/Terminals/PAX/Builders/HpsPaxGiftActivateBuilder.m
@@ -1,0 +1,63 @@
+#import "HpsPaxGiftActivateBuilder.h"
+
+@implementation HpsPaxGiftActivateBuilder
+
+- (id)initWithDevice: (HpsPaxDevice*)paxDevice{
+    self = [super init];
+    if (self != nil)
+    {
+        device = paxDevice;
+        self.currencyType = HpsCurrencyCodes_USD;
+    }
+    return self;
+}
+
+- (void) execute:(void(^)(HpsPaxGiftResponse*, NSError*))responseBlock{
+    
+    [self validate];
+    
+    NSMutableArray *subgroups = [[NSMutableArray alloc] init];
+    
+    NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
+    [formatter setPositiveFormat:@"0.##"];
+    
+    HpsPaxAmountRequest *amounts = [[HpsPaxAmountRequest alloc] init];
+    amounts.transactionAmount = self.amount != nil ? [formatter stringFromNumber:[NSNumber numberWithDouble:[self.amount doubleValue] * 100]] : nil;
+    [subgroups addObject:amounts];
+    
+    HpsPaxAccountRequest *account = [[HpsPaxAccountRequest alloc] init];
+    if (self.giftCard != nil) {
+        account.accountNumber = self.giftCard.value;
+    }
+    [subgroups addObject:account];
+    
+    HpsPaxTraceRequest *traceRequest = [[HpsPaxTraceRequest alloc] init];
+    traceRequest.referenceNumber = [NSString stringWithFormat:@"%d", self.referenceNumber];
+    [subgroups addObject:traceRequest];
+    
+    [subgroups addObject:[[HpsPaxCashierSubGroup alloc] init]];
+    
+    HpsPaxExtDataSubGroup *extData = [[HpsPaxExtDataSubGroup alloc] init];
+    [subgroups addObject:extData];
+    
+    NSString *messageId = self.currencyType == HpsCurrencyCodes_USD ? T06_DO_GIFT : T08_DO_LOYALTY;
+    
+    [device doGift:messageId withTxnType:PAX_TXN_TYPE_ACTIVATE andSubGroups:subgroups withResponseBlock:^(HpsPaxGiftResponse *response, NSError *error) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            responseBlock(response, error);
+        });
+    }];
+}
+
+- (void) validate
+{
+    if (self.amount == nil || self.amount <= 0) {
+        @throw [NSException exceptionWithName:@"HpsPaxException" reason:@"Amount is required." userInfo:nil];
+    }
+    if (self.currencyType < 0) {
+        @throw [NSException exceptionWithName:@"HpsPaxException" reason:@"currencyType is required." userInfo:nil];
+    }
+    
+}
+
+@end


### PR DESCRIPTION
Same as PaxGiftAddValue builder, but for activating new cards with a starting value. Needed for a complete end-to-end gift integration.