### PR TITLE
weaken gms builder-device reference, gms-level inits -> internal, consolidate subclass inits

### DIFF
--- a/Example/Tests/C2X/Hps_C2X_Credit_Test.m
+++ b/Example/Tests/C2X/Hps_C2X_Credit_Test.m
@@ -24,7 +24,7 @@
     config.deviceID = @"6398417";
     config.licenseID = @"142826";
     
-    self.device = [HpsC2xDevice initWithConfig:config];
+    self.device = [[HpsC2xDevice alloc] initWithConfig:config];
 }
 - (HpsCreditCard*) getCC
 {

--- a/Example/Tests/C2X/Hps_C2X_Credit_Test.m
+++ b/Example/Tests/C2X/Hps_C2X_Credit_Test.m
@@ -80,8 +80,7 @@
     [self.device initialize];
     self.device.deviceDelegate = self;
     transactionExpectation = [self expectationWithDescription:@"test_C2X_Credit_Sale_Manual"];
-    HpsC2xCreditSaleBuilder *builder = [[HpsC2xCreditSaleBuilder alloc] init];
-    builder.device = self.device;
+    HpsC2xCreditSaleBuilder *builder = [[HpsC2xCreditSaleBuilder alloc] initWithDevice:self.device];
     builder.amount = [[NSDecimalNumber alloc] initWithDouble:11.00];
     builder.gratuity = [[NSDecimalNumber alloc] initWithDouble:1.0];
     builder.creditCard = [self getCC];
@@ -108,8 +107,7 @@
     [self waitForExpectationsWithTimeout:60.0 handler:^(NSError *error) {
         if(error) XCTFail(@"Request Timed out");
         transactionExpectation = [self expectationWithDescription:@"test_C2X_Credit_Sale"];
-        HpsC2xCreditSaleBuilder *builder = [[HpsC2xCreditSaleBuilder alloc] init];
-        builder.device = self.device;
+        HpsC2xCreditSaleBuilder *builder = [[HpsC2xCreditSaleBuilder alloc] initWithDevice:self.device];
         builder.amount = [[NSDecimalNumber alloc]initWithDouble:12.00];
         builder.gratuity = [[NSDecimalNumber alloc]initWithDouble:0.0];
         self.device.transactionDelegate = self;
@@ -129,8 +127,7 @@
     [self.device initialize];
     self.device.deviceDelegate = self;
     transactionExpectation = [self expectationWithDescription:@"test_C2X_CreditSale"];
-    HpsC2xCreditAuthBuilder *builder = [[HpsC2xCreditAuthBuilder alloc] init];
-    builder.device = self.device;
+    HpsC2xCreditAuthBuilder *builder = [[HpsC2xCreditAuthBuilder alloc] initWithDevice:self.device];
     builder.amount = [[NSDecimalNumber alloc]initWithDouble:11.00];
     builder.gratuity = [[NSDecimalNumber alloc]initWithDouble:0.0];
     builder.creditCard = [self getCC];
@@ -150,7 +147,7 @@
     [self.device initialize];
     self.device.deviceDelegate = self;
     transactionExpectation = [self expectationWithDescription:@"test_C2X_Credit_Auth_Manual"];
-    HpsC2xCreditAuthBuilder *builder = [HpsC2xCreditAuthBuilder initWithDevice:self.device];
+    HpsC2xCreditAuthBuilder *builder = [[HpsC2xCreditAuthBuilder alloc] initWithDevice:self.device];
     builder.amount = [[NSDecimalNumber alloc] initWithDouble:11.00];
     builder.gratuity = [[NSDecimalNumber alloc] initWithDouble:0.0];
     builder.creditCard = [self getCC];
@@ -161,7 +158,7 @@
         XCTAssertNotNil(self.response);
         XCTAssertEqualObjects(@"APPROVAL", self.response.deviceResponseCode);
         transactionExpectation = [self expectationWithDescription:@"test_C2X_Credit_Capture"];
-        HpsC2xCreditCaptureBuilder *builder = [HpsC2xCreditCaptureBuilder initWithDevice:self.device];
+        HpsC2xCreditCaptureBuilder *builder = [[HpsC2xCreditCaptureBuilder alloc] initWithDevice:self.device];
         builder.amount = [[NSDecimalNumber alloc]initWithDouble:11.00];
         builder.transactionId = self.response.transactionId;
         builder.referenceNumber = self.response.terminalRefNumber;
@@ -209,7 +206,7 @@
     [self.device initialize];
     self.device.deviceDelegate = self;
     transactionExpectation = [self expectationWithDescription:@"test_C2X_Credit_Sale_Manual"];
-    HpsC2xCreditSaleBuilder *builder = [HpsC2xCreditSaleBuilder initWithDevice:self.device];
+    HpsC2xCreditSaleBuilder *builder = [[HpsC2xCreditSaleBuilder alloc] initWithDevice:self.device];
     builder.amount = [[NSDecimalNumber alloc] initWithDouble:11.00];
     builder.gratuity = [[NSDecimalNumber alloc] initWithDouble:0.0];
     builder.creditCard = [self getCC];
@@ -220,7 +217,7 @@
         XCTAssertNotNil(self.response);
         XCTAssertEqualObjects(@"APPROVAL", self.response.deviceResponseCode);
         transactionExpectation = [self expectationWithDescription:@"test_C2X_Credit_Refund"];
-        HpsC2xCreditReturnBuilder *builder = [HpsC2xCreditReturnBuilder initWithDevice:self.device];
+        HpsC2xCreditReturnBuilder *builder = [[HpsC2xCreditReturnBuilder alloc] initWithDevice:self.device];
         builder.amount = [[NSDecimalNumber alloc]initWithDouble:1.00];
         builder.transactionId = self.response.transactionId;
         builder.referenceNumber = self.response.terminalRefNumber;
@@ -242,7 +239,7 @@
     [self.device initialize];
     self.device.deviceDelegate = self;
     transactionExpectation = [self expectationWithDescription:@"test_C2X_Credit_Auth_Manual"];
-    HpsC2xCreditAuthBuilder *builder = [HpsC2xCreditAuthBuilder initWithDevice:self.device];
+    HpsC2xCreditAuthBuilder *builder = [[HpsC2xCreditAuthBuilder alloc] initWithDevice:self.device];
     builder.amount = [[NSDecimalNumber alloc] initWithDouble:11.00];
     builder.gratuity = [[NSDecimalNumber alloc] initWithDouble:0.0];
     builder.creditCard = [self getCC];
@@ -253,7 +250,7 @@
         XCTAssertNotNil(self.response);
         XCTAssertEqualObjects(@"APPROVAL", self.response.deviceResponseCode);
         transactionExpectation = [self expectationWithDescription:@"test_C2X_Credit_Void"];
-        HpsC2xCreditVoidBuilder *builder = [HpsC2xCreditVoidBuilder initWithDevice:self.device];
+        HpsC2xCreditVoidBuilder *builder = [[HpsC2xCreditVoidBuilder alloc] initWithDevice:self.device];
         builder.transactionId = self.response.transactionId;
         builder.referenceNumber = self.response.terminalRefNumber;
         self.device.transactionDelegate = self;
@@ -274,7 +271,7 @@
     [self.device initialize];
     self.device.deviceDelegate = self;
     transactionExpectation = [self expectationWithDescription:@"test_C2X_Credit_Sale_Manual"];
-    HpsC2xCreditSaleBuilder *builder = [HpsC2xCreditSaleBuilder initWithDevice:self.device];
+    HpsC2xCreditSaleBuilder *builder = [[HpsC2xCreditSaleBuilder alloc] initWithDevice:self.device];
     builder.amount = [[NSDecimalNumber alloc] initWithDouble:10.00];
     builder.gratuity = [[NSDecimalNumber alloc] initWithDouble:0.0];
     builder.creditCard = [self getCC];
@@ -285,8 +282,7 @@
         XCTAssertNotNil(self.response);
         XCTAssertEqualObjects(@"APPROVAL", self.response.deviceResponseCode);
         transactionExpectation = [self expectationWithDescription:@"test_C2X_Credit_Adjust"];
-        HpsC2xCreditAdjustBuilder *builder = [[HpsC2xCreditAdjustBuilder alloc] init];
-        builder.device = self.device;
+        HpsC2xCreditAdjustBuilder *builder = [[HpsC2xCreditAdjustBuilder alloc] initWithDevice:self.device];
         builder.amount = [[NSDecimalNumber alloc]initWithDouble: 11.00];
         builder.gratuity = [[NSDecimalNumber alloc]initWithDouble: 1.00];
         builder.transactionId = self.response.transactionId;
@@ -310,8 +306,7 @@
     [self.device initialize];
     self.device.deviceDelegate = self;
     transactionExpectation = [self expectationWithDescription:@"test_C2X_Batch_Close"];
-    HpsC2xBatchCloseBuilder *builder = [[HpsC2xBatchCloseBuilder alloc] init];
-    builder.device = self.device;
+    HpsC2xBatchCloseBuilder *builder = [[HpsC2xBatchCloseBuilder alloc] initWithDevice:self.device];
     self.device.transactionDelegate = self;
     [builder execute];
     [self waitForExpectationsWithTimeout:60.0 handler:^(NSError *error) {

--- a/Example/Tests/C2X/Hps_C2X_Credit_Test.m
+++ b/Example/Tests/C2X/Hps_C2X_Credit_Test.m
@@ -83,7 +83,7 @@
     HpsC2xCreditSaleBuilder *builder = [[HpsC2xCreditSaleBuilder alloc] init];
     builder.device = self.device;
     builder.amount = [[NSDecimalNumber alloc] initWithDouble:11.00];
-    builder.gratuity = [[NSDecimalNumber alloc] initWithDouble:0.0];
+    builder.gratuity = [[NSDecimalNumber alloc] initWithDouble:1.0];
     builder.creditCard = [self getCC];
     self.device.transactionDelegate = self;
     [builder execute];
@@ -91,6 +91,10 @@
         if(error) XCTFail(@"Request Timed out");
         XCTAssertNotNil(self.response);
         XCTAssertEqualObjects(@"APPROVAL", self.response.deviceResponseCode);
+        NSLog(@"approved amount: %@", self.response.approvedAmount);
+        NSLog(@"gratuity amount: %@", self.response.tipAmount);
+        XCTAssertNotNil(self.response.approvedAmount);
+        XCTAssertTrue(self.response.approvedAmount > 0);
     }];
     XCTAssert(YES, @"Device Connected");
 }

--- a/Example/Tests/C2X/Hps_C2X_Device_Test.m
+++ b/Example/Tests/C2X/Hps_C2X_Device_Test.m
@@ -23,8 +23,7 @@
     config.siteID = @"142914";
     config.deviceID = @"6399854";
     config.licenseID = @"142827";
-    self.device = [[HpsC2xDevice alloc] init];
-    self.device.config = config;
+    self.device = [[HpsC2xDevice alloc] initWithConfig:config];
 }
 
 - (HpsCreditCard*) getCC

--- a/Pod/Classes/Terminals/C2X/Builders/HpsC2xBatchCloseBuilder.swift
+++ b/Pod/Classes/Terminals/C2X/Builders/HpsC2xBatchCloseBuilder.swift
@@ -2,9 +2,8 @@ import Foundation
 
 @objcMembers
 public class HpsC2xBatchCloseBuilder : HpsC2xBaseBuilder, GMSBatchCloseBuilder {
-    public required init() {
-        super.init()
-        self.transactionType = .batchClose
+    public init(device: HpsC2xDevice) {
+        super.init(transactionType: .batchClose, device: device)
     }
     
     public override func buildRequest() -> Transaction? {

--- a/Pod/Classes/Terminals/C2X/Builders/HpsC2xCreditAdjustBuilder.swift
+++ b/Pod/Classes/Terminals/C2X/Builders/HpsC2xCreditAdjustBuilder.swift
@@ -10,9 +10,8 @@ public class HpsC2xCreditAdjustBuilder : HpsC2xBaseBuilder, GMSCreditAdjustBuild
     public var cardHolderName: String?
     public var address: HpsAddress?
 
-    public required init() {
-        super.init()
-        self.transactionType = .creditAdjust
+    public init(device: HpsC2xDevice) {
+        super.init(transactionType: .creditAdjust, device: device)
     }
     
     public override func buildRequest() -> Transaction? {

--- a/Pod/Classes/Terminals/C2X/Builders/HpsC2xCreditAuthBuilder.swift
+++ b/Pod/Classes/Terminals/C2X/Builders/HpsC2xCreditAuthBuilder.swift
@@ -11,9 +11,8 @@ public class HpsC2xCreditAuthBuilder : HpsC2xBaseBuilder, GMSCreditAuthBuilder {
     public var creditCard: HpsCreditCard?
     public var address: HpsAddress?
     
-    public required init() {
-        super.init()
-        self.transactionType = .creditAuth
+    public init(device: HpsC2xDevice) {
+        super.init(transactionType: .creditAuth, device: device)
     }
     
     public override func buildRequest() -> Transaction? {

--- a/Pod/Classes/Terminals/C2X/Builders/HpsC2xCreditCaptureBuilder.swift
+++ b/Pod/Classes/Terminals/C2X/Builders/HpsC2xCreditCaptureBuilder.swift
@@ -7,9 +7,8 @@ public class HpsC2xCreditCaptureBuilder : HpsC2xBaseBuilder, GMSCreditCaptureBui
     public var gratuity: NSDecimalNumber?
     public var transactionId: String?
     
-    public required init() {
-        super.init()
-        self.transactionType = .creditCapture
+    public init(device: HpsC2xDevice) {
+        super.init(transactionType: .creditCapture, device: device)
     }
     
     public override func buildRequest() -> Transaction? {

--- a/Pod/Classes/Terminals/C2X/Builders/HpsC2xCreditReturnBuilder.swift
+++ b/Pod/Classes/Terminals/C2X/Builders/HpsC2xCreditReturnBuilder.swift
@@ -6,9 +6,8 @@ public class HpsC2xCreditReturnBuilder : HpsC2xBaseBuilder, GMSCreditReturnBuild
     public var referenceNumber: String?
     public var transactionId: String?
     
-    public required init() {
-        super.init()
-        self.transactionType = .creditReturn
+    public init(device: HpsC2xDevice) {
+        super.init(transactionType: .creditReturn, device: device)
     }
     
     public override func buildRequest() -> Transaction? {

--- a/Pod/Classes/Terminals/C2X/Builders/HpsC2xCreditSaleBuilder.swift
+++ b/Pod/Classes/Terminals/C2X/Builders/HpsC2xCreditSaleBuilder.swift
@@ -11,9 +11,8 @@ public class HpsC2xCreditSaleBuilder : HpsC2xBaseBuilder, GMSCreditSaleBuilder {
     public var creditCard: HpsCreditCard?
     public var address: HpsAddress?
     
-    public required init() {
-        super.init()
-        self.transactionType = .creditSale
+    public init(device: HpsC2xDevice) {
+        super.init(transactionType: .creditSale, device: device)
     }
     
     public override func buildRequest() -> Transaction? {

--- a/Pod/Classes/Terminals/C2X/Builders/HpsC2xCreditVoidBuilder.swift
+++ b/Pod/Classes/Terminals/C2X/Builders/HpsC2xCreditVoidBuilder.swift
@@ -5,9 +5,8 @@ public class HpsC2xCreditVoidBuilder : HpsC2xBaseBuilder, GMSCreditVoidBuilder {
     public var referenceNumber: String?
     public var transactionId: String?
     
-    public required init() {
-        super.init()
-        self.transactionType = .creditVoid
+    public init(device: HpsC2xDevice) {
+        super.init(transactionType: .creditVoid, device: device)
     }
     
     public override func buildRequest() -> Transaction? {

--- a/Pod/Classes/Terminals/C2X/HpsC2xDevice.swift
+++ b/Pod/Classes/Terminals/C2X/HpsC2xDevice.swift
@@ -3,15 +3,16 @@ import GlobalMobileSDK
 
 @objcMembers
 public class HpsC2xDevice : GMSDevice, IC2xDeviceInterface {
-    public override func initialize() {
-        guard let config = self.config else { return }
-        let entryModes: [EntryMode] = [
-            .contact,
-            .chipFallback,
-            .msr,
-            .manual
-        ]
-        self.gmsWrapper = GMSWrapper(GMSConfiguration.fromHpsConnectionConfig(config), delegate: self, entryModes: entryModes, terminalType: .bbpos_c2x)
-        self.scan()
+    public init(config: HpsConnectionConfig) {
+        super.init(
+            config: config,
+            entryModes: [
+                .contact,
+                .chipFallback,
+                .msr,
+                .manual
+            ],
+            terminalType: .bbpos_c2x
+        )
     }
 }

--- a/Pod/Classes/Terminals/Utility/GlobalMobileSDK/GMSBaseBuilder.swift
+++ b/Pod/Classes/Terminals/Utility/GlobalMobileSDK/GMSBaseBuilder.swift
@@ -2,23 +2,17 @@ import Foundation
 
 @objcMembers
 public class GMSBaseBuilder : NSObject {
-    public var transactionType = HpsTransactionType.unknown
-    public var device: GMSDeviceInterface?
+    public let transactionType: HpsTransactionType
+    public unowned let device: GMSDeviceInterface
     
-    public required override init() {
+    internal init(transactionType: HpsTransactionType, device: GMSDeviceInterface) {
+        self.transactionType = transactionType
+        self.device = device
         super.init()
     }
     
-    public static func initWithDevice(_ device: GMSDeviceInterface) -> Self {
-        let result = self.init()
-        result.device = device
-        return result
-    }
-    
     public func execute() {
-        if let device = self.device {
-            device.processTransactionWithRequest(self, withTransactionType: self.transactionType)
-        }
+        device.processTransactionWithRequest(self, withTransactionType: self.transactionType)
     }
 
     public func buildRequest() -> Transaction? {

--- a/Pod/Classes/Terminals/Utility/GlobalMobileSDK/GMSDevice.swift
+++ b/Pod/Classes/Terminals/Utility/GlobalMobileSDK/GMSDevice.swift
@@ -2,26 +2,22 @@ import Foundation
 
 @objcMembers
 public class GMSDevice: NSObject, GMSClientAppDelegate, GMSDeviceInterface {
-    public var config: HpsConnectionConfig?
     public var gmsWrapper: GMSWrapper?
     public var deviceDelegate: GMSDeviceDelegate?
     public var transactionDelegate: GMSTransactionDelegate?
-    public var peripherals: NSMutableArray?
+    public var peripherals = NSMutableArray()
     
-    public required override init() {
+    internal init(config: HpsConnectionConfig, entryModes: [EntryMode], terminalType: TerminalType) {
         super.init()
-        self.peripherals = NSMutableArray()
-    }
-    
-    public static func initWithConfig(_ config: HpsConnectionConfig) -> Self {
-        let result = self.init()
-        result.config = config
-        return result
+        self.gmsWrapper = .init(
+            .fromHpsConnectionConfig(config),
+            delegate: self,
+            entryModes: entryModes,
+            terminalType: terminalType
+        )
     }
     
     public func initialize() {
-        guard let config = self.config else { return }
-        self.gmsWrapper = GMSWrapper(GMSConfiguration.fromHpsConnectionConfig(config), delegate: self, entryModes: [], terminalType: .none)
         self.scan()
     }
     
@@ -69,13 +65,11 @@ public class GMSDevice: NSObject, GMSClientAppDelegate, GMSDeviceInterface {
     }
 
     public func searchComplete() {
-        self.deviceDelegate?.onBluetoothDeviceList(self.peripherals ?? [])
+        self.deviceDelegate?.onBluetoothDeviceList(self.peripherals)
     }
 
     public func deviceFound(_ device: NSObject) {
-        if let peripherals = self.peripherals {
-            peripherals.add(device)
-        }
+        peripherals.add(device)
     }
 
     public func onStatus(_ status: HpsTransactionStatus) {

--- a/Pod/Classes/Terminals/Utility/GlobalMobileSDK/GMSResponseHelper.swift
+++ b/Pod/Classes/Terminals/Utility/GlobalMobileSDK/GMSResponseHelper.swift
@@ -52,11 +52,13 @@ class GMSResponseHelper {
         data.terminalVerficationResult = resp?.tvr
 
         if let decimalValue = resp?.tip {
-            data.tipAmount = NSNumber(nonretainedObject: decimalValue)
+            let doubleValue = NSDecimalNumber(decimal: decimalValue).doubleValue
+            data.tipAmount = NSNumber(value: doubleValue)
         }
-
+        
         if let decimalValue = resp?.total {
-            data.transactionAmount = NSNumber(nonretainedObject: decimalValue)
+            let doubleValue = NSDecimalNumber(decimal: decimalValue).doubleValue
+            data.transactionAmount = NSNumber(value: doubleValue)
         }
 
         return data
@@ -90,19 +92,21 @@ class GMSResponseHelper {
         data.responseText = resp?.gatewayResponseText
         data.deviceResponseCode = deviceResponseCode
         data.terminalRefNumber = resp?.posReferenceNumber
-//        data.transactionType = HpsC2xEnums.transactionTypeToString(resp?.transactionType)
+        data.transactionType = HpsC2xEnums.transactionTypeToString(.Return)
         data.applicationId = resp?.aid
         data.applicationName = resp?.applicationLabel
         data.cardholderName = resp?.cardholderName
         data.applicationCrytptogram = resp?.applicationCryptogram
         data.terminalVerficationResult = resp?.tvr
-
+        
         if let decimalValue = resp?.tip {
-            data.tipAmount = NSNumber(nonretainedObject: decimalValue)
+            let doubleValue = NSDecimalNumber(decimal: decimalValue).doubleValue
+            data.tipAmount = NSNumber(value: doubleValue)
         }
-
+        
         if let decimalValue = resp?.total {
-            data.transactionAmount = NSNumber(nonretainedObject: decimalValue)
+            let doubleValue = NSDecimalNumber(decimal: decimalValue).doubleValue
+            data.transactionAmount = NSNumber(value: doubleValue)
         }
         
         return data
@@ -122,19 +126,21 @@ class GMSResponseHelper {
         data.responseText = resp?.gatewayResponseText
         data.deviceResponseCode = deviceResponseCode
         data.terminalRefNumber = resp?.posReferenceNumber
-//        data.transactionType = HpsC2xEnums.transactionTypeToString(resp?.transactionType)
+        data.transactionType = HpsC2xEnums.transactionTypeToString(.Sale)
         data.applicationId = resp?.aid
         data.applicationName = resp?.applicationLabel
         data.cardholderName = resp?.cardholderName
         data.applicationCrytptogram = resp?.applicationCryptogram
         data.terminalVerficationResult = resp?.tvr
-
+        
         if let decimalValue = resp?.tip {
-            data.tipAmount = NSNumber(nonretainedObject: decimalValue)
+            let doubleValue = NSDecimalNumber(decimal: decimalValue).doubleValue
+            data.tipAmount = NSNumber(value: doubleValue)
         }
-
+        
         if let decimalValue = resp?.total {
-            data.transactionAmount = NSNumber(nonretainedObject: decimalValue)
+            let doubleValue = NSDecimalNumber(decimal: decimalValue).doubleValue
+            data.transactionAmount = NSNumber(value: doubleValue)
         }
         
         return data
@@ -152,7 +158,7 @@ class GMSResponseHelper {
         data.responseText = resp?.gatewayResponseText
         data.deviceResponseCode = deviceResponseCode
         data.terminalRefNumber = resp?.posReferenceNumber
-//        data.transactionType = HpsC2xEnums.transactionTypeToString(resp?.transactionType)
+        data.transactionType = HpsC2xEnums.transactionTypeToString(.Void)
 
         return data
     }

--- a/Pod/Classes/Terminals/Utility/GlobalMobileSDK/GMSWrapper.swift
+++ b/Pod/Classes/Terminals/Utility/GlobalMobileSDK/GMSWrapper.swift
@@ -7,7 +7,7 @@ public class GMSWrapper: NSObject {
 
     // MARK: Variables
     private var gatewayConfig: GMSConfiguration?
-    private var delegate: GMSClientAppDelegate?
+    private unowned let delegate: GMSClientAppDelegate
     private var selectedTerminal: HpsTerminalInfo?
     private var aids: [AID]?
     private var entryModes: [EntryMode]
@@ -15,7 +15,7 @@ public class GMSWrapper: NSObject {
     private var builder: GMSBaseBuilder?
 
     // MARK: Init
-    public init(_ gatewayConfig: GMSConfiguration?, delegate: GMSClientAppDelegate?, entryModes: [EntryMode], terminalType: TerminalType) {
+    public init(_ gatewayConfig: GMSConfiguration?, delegate: GMSClientAppDelegate, entryModes: [EntryMode], terminalType: TerminalType) {
         self.gatewayConfig = gatewayConfig
         self.delegate = delegate
         self.transactionType = .unknown
@@ -81,7 +81,7 @@ public class GMSWrapper: NSObject {
             
             builder?.execute({ (gatewayResponse, gatewayError) in
                 if (gatewayError != nil) {
-                    self.delegate?.onError(gatewayError! as NSError)
+                    self.delegate.onError(gatewayError! as NSError)
                     return
                 }
                 
@@ -89,7 +89,7 @@ public class GMSWrapper: NSObject {
                 response.transactionId = gatewayResponse?.transactionId()
                 response.deviceResponseCode = "Success"
                 
-                self.delegate?.onTransactionComplete(TransactionResult.success.rawValue, response: response)
+                self.delegate.onTransactionComplete(TransactionResult.success.rawValue, response: response)
             })
         default:
             break;
@@ -109,15 +109,15 @@ extension GMSWrapper: SearchDelegate {
 
     // MARK: SearchDelegate
     public func deviceFound(terminalInfo: TerminalInfo) {
-        delegate?.deviceFound(HpsTerminalInfo.init(fromTerminalInfo: terminalInfo))
+        delegate.deviceFound(HpsTerminalInfo.init(fromTerminalInfo: terminalInfo))
     }
 
     public func onSearchComplete() {
-        delegate?.searchComplete()
+        delegate.searchComplete()
     }
 
     public func onError(error: SearchError) {
-        delegate?.onError(NSError.init(fromSearchError: error));
+        delegate.onError(NSError.init(fromSearchError: error));
     }
 }
 
@@ -126,20 +126,20 @@ extension GMSWrapper: ConnectionDelegate {
     // MARK: ConnectionDelegate
     public func onConnected(terminalInfo: TerminalInfo) {
         selectedTerminal = HpsTerminalInfo.init(fromTerminalInfo: terminalInfo)
-        delegate?.deviceConnected()//(selectedTerminal)
+        delegate.deviceConnected()//(selectedTerminal)
     }
 
     public func onDisconnected(terminalInfo: TerminalInfo) {
         selectedTerminal = nil
-        delegate?.deviceDisconnected()
+        delegate.deviceDisconnected()
     }
 
     public func configuringTerminal(state: TransactionState) {
-        delegate?.deviceConnected()
+        delegate.deviceConnected()
     }
 
     public func onError(error: ConnectionError) {
-        delegate?.onError(NSError.init(fromConnectionError: error));
+        delegate.onError(NSError.init(fromConnectionError: error));
     }
 }
 
@@ -147,23 +147,23 @@ extension GMSWrapper: TransactionDelegate {
 
     // MARK: TransactionDelegate
     public func onState(state: TransactionState) {
-        delegate?.onStatus(HpsTransactionStatus.fromTransactionState(state))
+        delegate.onStatus(HpsTransactionStatus.fromTransactionState(state))
     }
 
     public func requestAIDSelection(aids: [AID]) {
-        delegate?.requestAIDSelection(aids)
+        delegate.requestAIDSelection(aids)
     }
 
     public func requestAmountConfirmation(amount: Decimal?) {
-        delegate?.requestAmountConfirmation(amount ?? 0)
+        delegate.requestAmountConfirmation(amount ?? 0)
     }
 
     public func requestPostalCode(maskedPan: String, expiryDate: String, cardholderName: String?) {
-        delegate?.requestPostalCode(maskedPan, expiryDate: expiryDate, cardholderName: cardholderName ?? "")
+        delegate.requestPostalCode(maskedPan, expiryDate: expiryDate, cardholderName: cardholderName ?? "")
     }
 
     public func requestSaFApproval() {
-        delegate?.requestSaFApproval()
+        delegate.requestSaFApproval()
     }
 
     public func onTransactionComplete(result: TransactionResult, response: TransactionResponse?) {
@@ -180,14 +180,14 @@ extension GMSWrapper: TransactionDelegate {
             data = b.mapResponse(data, result, response)
         }
 
-        delegate?.onTransactionComplete(result.rawValue, response: data)
+        delegate.onTransactionComplete(result.rawValue, response: data)
     }
 
     public func onTransactionCancelled() {
-        delegate?.onTransactionCancelled()
+        delegate.onTransactionCancelled()
     }
 
     public func onError(error: TransactionError) {
-        delegate?.onError(NSError.init(fromTransactionError: error));
+        delegate.onError(NSError.init(fromTransactionError: error));
     }
 }

--- a/Pod/Classes/Terminals/Utility/GlobalMobileSDK/GMSWrapper.swift
+++ b/Pod/Classes/Terminals/Utility/GlobalMobileSDK/GMSWrapper.swift
@@ -171,8 +171,9 @@ extension GMSWrapper: TransactionDelegate {
 
         data.transactionId = response?.gatewayTransactionId
         
-        if let approvedAmount = response?.approvedAmount {
-            data.approvedAmount = NSNumber(nonretainedObject: approvedAmount);
+        if let decimalValue = response?.approvedAmount {
+            let doubleValue = NSDecimalNumber(decimal: decimalValue).doubleValue
+            data.approvedAmount = NSNumber(value: doubleValue)
         }
 
         if let b = self.builder {

--- a/Pod/Classes/Terminals/WiseCube/Builders/HpsWiseCubeBatchCloseBuilder.swift
+++ b/Pod/Classes/Terminals/WiseCube/Builders/HpsWiseCubeBatchCloseBuilder.swift
@@ -2,9 +2,8 @@ import Foundation
 
 @objcMembers
 public class HpsWiseCubeBatchCloseBuilder : HpsWiseCubeBaseBuilder, GMSBatchCloseBuilder {
-    public required init() {
-        super.init()
-        self.transactionType = .batchClose
+    public init(device: HpsWiseCubeDevice) {
+        super.init(transactionType: .batchClose, device: device)
     }
     
     public override func buildRequest() -> Transaction? {

--- a/Pod/Classes/Terminals/WiseCube/Builders/HpsWiseCubeCreditAdjustBuilder.swift
+++ b/Pod/Classes/Terminals/WiseCube/Builders/HpsWiseCubeCreditAdjustBuilder.swift
@@ -10,9 +10,8 @@ public class HpsWiseCubeCreditAdjustBuilder : HpsWiseCubeBaseBuilder, GMSCreditA
     public var cardHolderName: String?
     public var address: HpsAddress?
 
-    public required init() {
-        super.init()
-        self.transactionType = .creditAdjust
+    public init(device: HpsWiseCubeDevice) {
+        super.init(transactionType: .creditAdjust, device: device)
     }
     
     public override func buildRequest() -> Transaction? {

--- a/Pod/Classes/Terminals/WiseCube/Builders/HpsWiseCubeCreditAuthBuilder.swift
+++ b/Pod/Classes/Terminals/WiseCube/Builders/HpsWiseCubeCreditAuthBuilder.swift
@@ -11,9 +11,8 @@ public class HpsWiseCubeCreditAuthBuilder : HpsWiseCubeBaseBuilder, GMSCreditAut
     public var creditCard: HpsCreditCard?
     public var address: HpsAddress?
     
-    public required init() {
-        super.init()
-        self.transactionType = .creditAuth
+    public init(device: HpsWiseCubeDevice) {
+        super.init(transactionType: .creditAuth, device: device)
     }
     
     public override func buildRequest() -> Transaction? {

--- a/Pod/Classes/Terminals/WiseCube/Builders/HpsWiseCubeCreditCaptureBuilder.swift
+++ b/Pod/Classes/Terminals/WiseCube/Builders/HpsWiseCubeCreditCaptureBuilder.swift
@@ -7,9 +7,8 @@ public class HpsWiseCubeCreditCaptureBuilder : HpsWiseCubeBaseBuilder, GMSCredit
     public var gratuity: NSDecimalNumber?
     public var transactionId: String?
     
-    public required init() {
-        super.init()
-        self.transactionType = .creditCapture
+    public init(device: HpsWiseCubeDevice) {
+        super.init(transactionType: .creditCapture, device: device)
     }
     
     public override func buildRequest() -> Transaction? {

--- a/Pod/Classes/Terminals/WiseCube/Builders/HpsWiseCubeCreditReturnBuilder.swift
+++ b/Pod/Classes/Terminals/WiseCube/Builders/HpsWiseCubeCreditReturnBuilder.swift
@@ -6,9 +6,8 @@ public class HpsWiseCubeCreditReturnBuilder : HpsWiseCubeBaseBuilder, GMSCreditR
     public var referenceNumber: String?
     public var transactionId: String?
     
-    public required init() {
-        super.init()
-        self.transactionType = .creditReturn
+    public init(device: HpsWiseCubeDevice) {
+        super.init(transactionType: .creditReturn, device: device)
     }
     
     public override func buildRequest() -> Transaction? {

--- a/Pod/Classes/Terminals/WiseCube/Builders/HpsWiseCubeCreditSaleBuilder.swift
+++ b/Pod/Classes/Terminals/WiseCube/Builders/HpsWiseCubeCreditSaleBuilder.swift
@@ -11,9 +11,8 @@ public class HpsWiseCubeCreditSaleBuilder : HpsWiseCubeBaseBuilder, GMSCreditSal
     public var creditCard: HpsCreditCard?
     public var address: HpsAddress?
     
-    public required init() {
-        super.init()
-        self.transactionType = .creditSale
+    public init(device: HpsWiseCubeDevice) {
+        super.init(transactionType: .creditSale, device: device)
     }
     
     public override func buildRequest() -> Transaction? {

--- a/Pod/Classes/Terminals/WiseCube/Builders/HpsWiseCubeCreditVoidBuilder.swift
+++ b/Pod/Classes/Terminals/WiseCube/Builders/HpsWiseCubeCreditVoidBuilder.swift
@@ -5,9 +5,8 @@ public class HpsWiseCubeCreditVoidBuilder : HpsWiseCubeBaseBuilder, GMSCreditVoi
     public var referenceNumber: String?
     public var transactionId: String?
     
-    public required init() {
-        super.init()
-        self.transactionType = .creditVoid
+    public init(device: HpsWiseCubeDevice) {
+        super.init(transactionType: .creditVoid, device: device)
     }
     
     public override func buildRequest() -> Transaction? {

--- a/Pod/Classes/Terminals/WiseCube/HpsWiseCubeDevice.swift
+++ b/Pod/Classes/Terminals/WiseCube/HpsWiseCubeDevice.swift
@@ -2,14 +2,15 @@ import Foundation
 
 @objcMembers
 public class HpsWiseCubeDevice : GMSDevice, IWiseCubeDeviceInterface {    
-    public override func initialize() {
-        guard let config = self.config else { return }
-        let entryModes: [EntryMode] = [
-            .contact,
-            .contactless,
-            .manual
-        ]
-        self.gmsWrapper = GMSWrapper(GMSConfiguration.fromHpsConnectionConfig(config), delegate: self, entryModes: entryModes, terminalType: .bbpos_wisecube)
-        self.scan()
+    public init(config: HpsConnectionConfig) {
+        super.init(
+            config: config,
+            entryModes: [
+                .contact,
+                .contactless,
+                .manual
+            ],
+            terminalType: .bbpos_wisecube
+        )
     }
 }


### PR DESCRIPTION
@slogsdon there was another retain cycle caused from storing a strong reference to GMSDevice inside GMS transaction builder types when calling `processTransactionWithRequest`.

I made it unowned cause I'm assuming `device` isn't going to change or be nil within individual transaction builders. In order to do that I also rewrote the builder inits so that subclass init's would be restricted to their corresponding device types. I also updated the device subclass inits in a similar fashion.

Let me know if there are any issues you see or if you have any questions.