### PR TITLE
Fixed getTokenWithCardNumber method not resuming the created NSURLSessionDataRequest

### DIFF
--- a/Pod/Classes/Services/HpsTokenService.m
+++ b/Pod/Classes/Services/HpsTokenService.m
@@ -120,7 +120,7 @@
     [request setValue:[@([jsonData length]) stringValue] forHTTPHeaderField:@"Content-Length"];
     [request setHTTPBody:jsonData];    
     
-    [[NSURLSession sharedSession] dataTaskWithRequest:request
+    NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:request
                                     completionHandler:^(NSData *data, NSURLResponse *urlResponse, NSError *error) {
                                if (error != nil){
                                    
@@ -194,6 +194,8 @@
                                }
                                
                            }];
+    
+    [task resume];
 }
 
 - (NSString*) dataOrDefault:(NSString*)data


### PR DESCRIPTION
I discovered that the card tokenization service was not working.

Under further investigation I found that the getTokenWithCardDictionary method wasn't sending the request to the remote server because it was missing the resume method call on the NSURLSessionDataTask.

This caused the library to don't make the request to Heartland's servers and therefore the app never had a response from the tokenization service.

I added the resume call and the service is working as intended.